### PR TITLE
To avoid unnecessary repeated pip package download and installations …

### DIFF
--- a/balena-cam/Dockerfile.template
+++ b/balena-cam/Dockerfile.template
@@ -27,15 +27,15 @@ RUN apt-get update && \
     libavcodec-dev \
   && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-WORKDIR /usr/src/app
-
-COPY ./app/ /usr/src/app/
-
 # Enable the v4l2 driver for the Raspberry Pi camera
 #RUN printf "bcm2835-v4l2\n" >> /etc/modules
 RUN pip3 install --upgrade pip 
 RUN pip3 install async-timeout
 RUN pip3 install aiohttp aiohttp_basicauth==0.1.3 aiortc==0.9.11 numpy==1.15.4 opencv-python==3.4.4.19 --index-url https://www.piwheels.org/simple
 RUN pip3 install av
+
+WORKDIR /usr/src/app
+
+COPY ./app/ /usr/src/app/
 
 CMD ["python3", "/usr/src/app/server.py"]


### PR DESCRIPTION
…when changing the source code, it is not copied after so that completed build steps are reused

This makes it much more convenient to tinker with the source code without wasting time on pip installs to complete every time you want to build and run it.